### PR TITLE
@Alexrdj11 Add sprint delete method with tests and cleanup

### DIFF
--- a/pyscrum/sprint.py
+++ b/pyscrum/sprint.py
@@ -11,8 +11,10 @@ class Sprint:
 
     def _load_tasks(self):
         """Load tasks assigned to this sprint from the database."""
+        self.tasks = []  # Clear existing tasks
         try:
             with get_connection() as conn:
+                # Ensure table exists
                 conn.execute("""
                     CREATE TABLE IF NOT EXISTS sprint_tasks (
                         sprint_name TEXT,
@@ -20,39 +22,59 @@ class Sprint:
                         PRIMARY KEY (sprint_name, task_id)
                     )
                 """)
+                
+                # Get unique task IDs for this sprint
                 cursor = conn.execute("""
-                    SELECT task_id FROM sprint_tasks WHERE sprint_name=?
+                    SELECT DISTINCT task_id 
+                    FROM sprint_tasks 
+                    WHERE sprint_name = ?
                 """, (self.name,))
-                task_ids = cursor.fetchall()
-                self.tasks = []
-                for task_id in task_ids:
+                
+                # Load each task
+                for (task_id,) in cursor.fetchall():
                     try:
-                        task = Task.load(task_id[0])
-                        self.tasks.append(task)
+                        task = Task.load(task_id)
+                        if task and not any(t.id == task.id for t in self.tasks):
+                            self.tasks.append(task)
                     except ValueError:
-                        pass
+                        continue
         except sqlite3.OperationalError:
-            self.tasks = []
+            pass
 
     def save(self):
         """Persist the sprint and task assignments to the database."""
         try:
             with get_connection() as conn:
-                conn.execute("""
-                    CREATE TABLE IF NOT EXISTS sprints (
-                        name TEXT PRIMARY KEY,
-                        status TEXT DEFAULT 'Planned'
-                    )
-                """)
-                conn.execute("""
-                    INSERT OR REPLACE INTO sprints (name, status)
-                    VALUES (?, ?)
-                """, (self.name, self.status))
-                for task in self.tasks:
+                conn.execute("BEGIN")
+                try:
+                    # Ensure sprints table exists
                     conn.execute("""
-                        INSERT OR IGNORE INTO sprint_tasks (sprint_name, task_id)
+                        CREATE TABLE IF NOT EXISTS sprints (
+                            name TEXT PRIMARY KEY,
+                            status TEXT DEFAULT 'Planned'
+                        )
+                    """)
+                    
+                    # Save sprint
+                    conn.execute("""
+                        INSERT OR REPLACE INTO sprints (name, status)
                         VALUES (?, ?)
-                    """, (self.name, task.id))
+                    """, (self.name, self.status))
+                    
+                    # Clear existing task assignments
+                    conn.execute("DELETE FROM sprint_tasks WHERE sprint_name = ?", (self.name,))
+                    
+                    # Save task assignments
+                    for task in self.tasks:
+                        conn.execute("""
+                            INSERT OR IGNORE INTO sprint_tasks (sprint_name, task_id)
+                            VALUES (?, ?)
+                        """, (self.name, task.id))
+                    
+                    conn.commit()
+                except Exception as e:
+                    conn.rollback()
+                    raise e
         except sqlite3.OperationalError:
             pass
 
@@ -60,16 +82,12 @@ class Sprint:
         """Add a Task to the sprint."""
         if not isinstance(task, Task):
             raise TypeError("Sprint accepts only Task instances.")
-
-        if any(t.id == task.id for t in self.tasks):
-            return  # Avoid duplicates
-
-        self.tasks.append(task)
-        try:
-            task.save()
-            self.save()
-        except (AttributeError, sqlite3.OperationalError):
-            pass
+        
+        # Only add if not already in tasks
+        if not any(t.id == task.id for t in self.tasks):
+            task.save()  # Ensure task is saved first
+            self.tasks.append(task)
+            self.save()  # Update sprint_tasks table
 
     def remove_task(self, task_or_id):
         """Remove a Task by object or ID."""
@@ -103,18 +121,54 @@ class Sprint:
 
     def update_name(self, new_name):
         """Update the sprint name in the DB and memory."""
-        old_name = self.name
+        if new_name == self.name:
+            return
+            
         try:
             with get_connection() as conn:
-                conn.execute("""
-                    UPDATE sprints SET name=? WHERE name=?
-                """, (new_name, old_name))
-                conn.execute("""
-                    UPDATE sprint_tasks SET sprint_name=? WHERE sprint_name=?
-                """, (new_name, old_name))
-            self.name = new_name  # Update in-memory only after DB update succeeds
-        except (sqlite3.OperationalError, sqlite3.IntegrityError):
+                conn.execute("BEGIN")
+                try:
+                    # Update sprint name
+                    conn.execute("""
+                        INSERT OR REPLACE INTO sprints (name, status)
+                        VALUES (?, ?)
+                    """, (new_name, self.status))
+                    
+                    # Update task assignments
+                    conn.execute("""
+                        UPDATE sprint_tasks 
+                        SET sprint_name = ? 
+                        WHERE sprint_name = ?
+                    """, (new_name, self.name))
+                    
+                    conn.commit()
+                    self.name = new_name
+                except Exception as e:
+                    conn.rollback()
+                    raise e
+        except sqlite3.OperationalError:
             pass
 
     def __repr__(self):
         return f"<Sprint {self.name}: {len(self.tasks)} tasks>"
+
+    @classmethod
+    def delete(cls, name):
+        """Remove a sprint and its associated tasks from the database.
+        
+        Args:
+            name (str): The name of the sprint to delete
+        """
+        try:
+            with get_connection() as conn:
+                # First delete from sprint_tasks to maintain referential integrity
+                conn.execute("""
+                    DELETE FROM sprint_tasks WHERE sprint_name=?
+                """, (name,))
+                
+                # Then delete the sprint itself
+                conn.execute("""
+                    DELETE FROM sprints WHERE name=?
+                """, (name,))
+        except sqlite3.OperationalError:
+            pass


### PR DESCRIPTION
Added a delete() classmethod to the Sprint class to remove a sprint and all its associated tasks from the database, ensuring proper referential integrity. Also added a test (test_sprint_deletion) to verify the functionality, along with a cleanup fixture for maintaining a clean test state. Minor improvements were made to handle task duplication and enhance error handling within database operations.