### PR TITLE
added sprint.delete() classmethod to remove sprint and related tasks

### DIFF
--- a/pyscrum/sprint.py
+++ b/pyscrum/sprint.py
@@ -118,3 +118,13 @@ class Sprint:
 
     def __repr__(self):
         return f"<Sprint {self.name}: {len(self.tasks)} tasks>"
+
+    @classmethod
+    def delete(cls, name):
+        """Delete a sprint from the database, including its tasks from the sprint_tasks table."""
+        try:
+            with get_connection() as conn:
+                conn.execute("DELETE FROM sprint_tasks WHERE sprint_name=?", (name,))
+                conn.execute("DELETE FROM sprints WHERE name=?", (name,))
+        except sqlite3.OperationalError:
+            pass


### PR DESCRIPTION
Implements the delete(name) classmethod in the sprint class to remove a sprint and its associated tasks from the db.
This update strictly follows the original issue instruction... no additional changes or test code added.